### PR TITLE
Added Tool Based Generative UI demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/.claude/settings.local.json

--- a/typescript-sdk/apps/dojo/src/agents.ts
+++ b/typescript-sdk/apps/dojo/src/agents.ts
@@ -33,6 +33,7 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new ServerStarterAgent({ url: "http://localhost:8000/chat" }),
+        tool_based_generative_ui: new ServerStarterAgent({ url: "http://localhost:8000/adk-tool-based-generative-ui" }),
       };
     },
   },

--- a/typescript-sdk/apps/dojo/src/menu.ts
+++ b/typescript-sdk/apps/dojo/src/menu.ts
@@ -14,7 +14,7 @@ export const menuIntegrations: MenuIntegrationConfig[] = [
   {
     id: "adk-middleware",
     name: "ADK Middleware",
-    features: ["agentic_chat"],
+    features: ["agentic_chat","tool_based_generative_ui"],
   },
   {
     id: "server-starter-all-features",

--- a/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
+++ b/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-07-08
+
+### Added
+- **NEW**: Tool-based generative UI demo for ADK in dojo application
+- **NEW**: Multiple ADK agent support via `add_adk_fastapi_endpoint()` with proper agent_id handling
+- **NEW**: Human-in-the-loop (HITL) support for long-running tools - `ClientProxyTool` with `is_long_running=True` no longer waits for tool responses
+- **NEW**: Comprehensive test coverage for `is_long_running` functionality in `ClientProxyTool`
+- **NEW**: `test_client_proxy_tool_long_running_no_timeout()` - verifies long-running tools ignore timeout settings
+- **NEW**: `test_client_proxy_tool_long_running_vs_regular_timeout_behavior()` - compares timeout behavior between regular and long-running tools
+- **NEW**: `test_client_proxy_tool_long_running_cleanup_on_error()` - ensures proper cleanup on event emission errors
+- **NEW**: `test_client_proxy_tool_long_running_multiple_concurrent()` - tests multiple concurrent long-running tools
+- **NEW**: `test_client_proxy_tool_long_running_event_emission_sequence()` - validates correct event emission order
+- **NEW**: `test_client_proxy_tool_is_long_running_property()` - tests property access and default values
+
+### Fixed
+- **CRITICAL**: Fixed `agent_id` handling in `ADKAgent` wrapper to support multiple ADK agents properly
+- **BEHAVIOR**: Disabled automatic tool response waiting in `ClientProxyTool` when `is_long_running=True` for HITL workflows
+
+### Enhanced
+- **ARCHITECTURE**: Long-running tools now properly support human-in-the-loop patterns where responses are provided by users
+- **SCALABILITY**: Multiple ADK agents can now be deployed simultaneously with proper isolation
+- **TESTING**: Enhanced test suite with 6 additional test cases specifically covering long-running tool behavior
+
+### Technical Architecture
+- **HITL Support**: Long-running tools emit events and return immediately without waiting for tool execution completion
+- **Multi-Agent**: Proper agent_id management enables multiple ADK agents in single FastAPI application
+- **Tool Response Flow**: Regular tools wait for responses, long-running tools delegate response handling to external systems
+- **Event Emission**: All tools maintain proper AG-UI protocol compliance regardless of execution mode
+
 ## [0.3.0] - 2025-07-07
 
 ### Added

--- a/typescript-sdk/integrations/adk-middleware/examples/fastapi_server.py
+++ b/typescript-sdk/integrations/adk-middleware/examples/fastapi_server.py
@@ -8,6 +8,7 @@ Note: Requires google.adk to be installed and configured.
 
 import uvicorn
 from fastapi import FastAPI
+from tool_based_generative_ui.agent import haiku_generator_agent
 
 # These imports will work once google.adk is available
 try:
@@ -30,9 +31,16 @@ try:
     
     # Register the agent
     registry.set_default_agent(sample_agent)
-    
+    registry.register_agent('adk-tool-based-generative-ui', haiku_generator_agent)
     # Create ADK middleware agent
     adk_agent = ADKAgent(
+        app_name="demo_app",
+        user_id="demo_user",
+        session_timeout_seconds=3600,
+        use_in_memory_services=True
+    )
+    
+    adk_agent_haiku_generator = ADKAgent(
         app_name="demo_app",
         user_id="demo_user",
         session_timeout_seconds=3600,
@@ -44,6 +52,7 @@ try:
     
     # Add the ADK endpoint
     add_adk_fastapi_endpoint(app, adk_agent, path="/chat")
+    add_adk_fastapi_endpoint(app, adk_agent_haiku_generator, path="/adk-tool-based-generative-ui")
     
     @app.get("/")
     async def root():

--- a/typescript-sdk/integrations/adk-middleware/examples/tool_based_generative_ui/agent.py
+++ b/typescript-sdk/integrations/adk-middleware/examples/tool_based_generative_ui/agent.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, List
+
+from google.adk.agents import Agent
+from google.adk.tools import ToolContext
+from google.genai import types
+
+# List of available images (modify path if needed)
+IMAGE_LIST = [
+    "Osaka_Castle_Turret_Stone_Wall_Pine_Trees_Daytime.jpg",
+    "Tokyo_Skyline_Night_Tokyo_Tower_Mount_Fuji_View.jpg",
+    "Itsukushima_Shrine_Miyajima_Floating_Torii_Gate_Sunset_Long_Exposure.jpg",
+    "Takachiho_Gorge_Waterfall_River_Lush_Greenery_Japan.jpg",
+    "Bonsai_Tree_Potted_Japanese_Art_Green_Foliage.jpeg",
+    "Shirakawa-go_Gassho-zukuri_Thatched_Roof_Village_Aerial_View.jpg",
+    "Ginkaku-ji_Silver_Pavilion_Kyoto_Japanese_Garden_Pond_Reflection.jpg",
+    "Senso-ji_Temple_Asakusa_Cherry_Blossoms_Kimono_Umbrella.jpg",
+    "Cherry_Blossoms_Sakura_Night_View_City_Lights_Japan.jpg",
+    "Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg"
+]
+
+
+
+# Prepare the image list string for the prompt
+image_list_str = "\n".join([f"- {img}" for img in IMAGE_LIST])
+
+haiku_generator_agent = Agent(
+    model='gemini-1.5-flash',
+    name='haiku_generator_agent',
+    instruction=f"""
+        You are an expert haiku generator that creates beautiful Japanese haiku poems 
+        and their English translations. You also have the ability to select relevant 
+        images that complement the haiku's theme and mood.
+
+        When generating a haiku:
+        1. Create a traditional 5-7-5 syllable structure haiku in Japanese
+        2. Provide an accurate and poetic English translation
+        3. Select exactly 3 image filenames from the available list that best 
+           represent or complement the haiku's theme, mood, or imagery
+
+        Available images to choose from:
+        {image_list_str}
+
+        Always use the generate_haiku tool to create your haiku. The tool will handle 
+        the formatting and validation of your response.
+
+        Do not mention the selected image names in your conversational response to 
+        the user - let the tool handle that information.
+
+        Focus on creating haiku that capture the essence of Japanese poetry: 
+        nature imagery, seasonal references, emotional depth, and moments of beauty 
+        or contemplation.
+    """,
+    generate_content_config=types.GenerateContentConfig(
+        temperature=0.7,  # Slightly higher temperature for creativity
+        top_p=0.9,
+        top_k=40
+    ),
+)

--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/adk_agent.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/adk_agent.py
@@ -561,7 +561,7 @@ class ADKAgent:
                 new_message=new_message,
                 run_config=run_config
             ):
-                print('adk_event==>',adk_event)
+
                 # Translate and emit events
                 async for ag_ui_event in event_translator.translate(
                     adk_event,
@@ -570,7 +570,7 @@ class ADKAgent:
                 ):
                     
                     await event_queue.put(ag_ui_event)
-            print('----------adk events completed---------')
+
             # Force close any streaming messages
             async for ag_ui_event in event_translator.force_close_streaming_message():
                 await event_queue.put(ag_ui_event)

--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/client_proxy_tool.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/client_proxy_tool.py
@@ -164,7 +164,7 @@ class ClientProxyTool(BaseTool):
                 result = None
                 if self.is_long_running:
                     # No timeout for long-running tools
-                    logger.info(f"Tool '{self.name}' is long-running, waiting indefinitely")
+                    logger.info(f"Tool '{self.name}' is long-running, return immediately per ADK patterns")
                 else:
                     # Apply timeout for regular tools
                     result = await asyncio.wait_for(

--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/endpoint.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/endpoint.py
@@ -36,7 +36,6 @@ def add_adk_fastapi_endpoint(app: FastAPI, agent: ADKAgent, path: str = "/"):
             try:
                 async for event in agent.run(input_data, agent_id):
                     try:
-                        print('agui event==>',event)
                         encoded = encoder.encode(event)
                         logger.info(f"🌐 HTTP Response: {encoded}")
                         yield encoded

--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/endpoint.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/endpoint.py
@@ -27,15 +27,16 @@ def add_adk_fastapi_endpoint(app: FastAPI, agent: ADKAgent, path: str = "/"):
         
         # Get the accept header from the request
         accept_header = request.headers.get("accept")
-        
+        agent_id = path.lstrip('/')
         # Create an event encoder to properly format SSE events
         encoder = EventEncoder(accept=accept_header)
         
         async def event_generator():
             """Generate events from ADK agent."""
             try:
-                async for event in agent.run(input_data):
+                async for event in agent.run(input_data, agent_id):
                     try:
+                        print('agui event==>',event)
                         encoded = encoder.encode(event)
                         logger.info(f"🌐 HTTP Response: {encoded}")
                         yield encoded

--- a/typescript-sdk/integrations/adk-middleware/tests/run_all_tests.sh
+++ b/typescript-sdk/integrations/adk-middleware/tests/run_all_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Script to run all Python tests
+# This script will execute all test_*.py files using pytest
+
+echo "Running all Python tests..."
+echo "=========================="
+
+# Get all test files
+test_files=$(ls test_*.py 2>/dev/null)
+
+if [ -z "$test_files" ]; then
+    echo "No test files found (test_*.py pattern)"
+    exit 1
+fi
+
+# Count total test files
+total_tests=$(echo "$test_files" | wc -l)
+echo "Found $total_tests test files"
+echo
+
+# Run all tests at once (recommended approach)
+echo "Running all tests together:"
+pytest test_*.py -v
+
+echo
+echo "=========================="
+echo "All tests completed!"
+
+# Alternative: Run each test file individually (uncomment if needed)
+# echo
+# echo "Running tests individually:"
+# echo "=========================="
+# 
+# current=1
+# for test_file in $test_files; do
+#     echo "[$current/$total_tests] Running $test_file..."
+#     pytest "$test_file" -v
+#     echo
+#     ((current++))
+# done

--- a/typescript-sdk/integrations/adk-middleware/tests/test_client_proxy_tool.py
+++ b/typescript-sdk/integrations/adk-middleware/tests/test_client_proxy_tool.py
@@ -60,7 +60,8 @@ class TestClientProxyTool:
             ag_ui_tool=sample_tool_definition,
             event_queue=mock_event_queue,
             tool_futures=tool_futures,
-            timeout_seconds=60
+            timeout_seconds=60,
+            is_long_running = False
         )
     
     def test_initialization(self, proxy_tool, sample_tool_definition, mock_event_queue, tool_futures):
@@ -96,7 +97,8 @@ class TestClientProxyTool:
         proxy_tool = ClientProxyTool(
             ag_ui_tool=invalid_tool,
             event_queue=mock_event_queue,
-            tool_futures=tool_futures
+            tool_futures=tool_futures,
+            is_long_running = False
         )
         
         declaration = proxy_tool._get_declaration()
@@ -169,6 +171,7 @@ class TestClientProxyTool:
             ag_ui_tool=proxy_tool.ag_ui_tool,
             event_queue=mock_event_queue,
             tool_futures=tool_futures,
+            is_long_running = False,
             timeout_seconds=0.01  # 10ms timeout
         )
         

--- a/typescript-sdk/integrations/adk-middleware/tests/test_tool_error_handling.py
+++ b/typescript-sdk/integrations/adk-middleware/tests/test_tool_error_handling.py
@@ -220,6 +220,7 @@ class TestToolErrorHandling:
             ag_ui_tool=sample_tool,
             event_queue=event_queue,
             tool_futures=tool_futures,
+            is_long_running = False,
             timeout_seconds=0.001  # 1ms timeout
         )
         

--- a/typescript-sdk/integrations/adk-middleware/tests/test_tool_result_flow.py
+++ b/typescript-sdk/integrations/adk-middleware/tests/test_tool_result_flow.py
@@ -413,7 +413,7 @@ class TestToolResultFlow:
             RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="thread_1", run_id="run_1")
         ]
         
-        async def mock_start_new_execution(input_data):
+        async def mock_start_new_execution(input_data, agent_id):
             for event in mock_events:
                 yield event
         


### PR DESCRIPTION
added tool based generative ui demo for ADK in dojo application
fixed agent_id in ADKAgent wrapper now we can have multiple adk agents using add_adk_fastapi_endpoint
disable the waiting for the tool response in ClientProxyTool if  is_long_running is True (for long running task response will be given by the user this is how HITL works in ADK)