### PR TITLE
fix: update test to check debug logging instead of info

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/tests/test_endpoint.py
+++ b/typescript-sdk/integrations/adk-middleware/tests/test_endpoint.py
@@ -183,7 +183,7 @@ class TestAddADKFastAPIEndpoint:
         
         # Check that events were encoded and logged
         assert mock_encoder.encode.call_count == 2
-        assert mock_logger.info.call_count == 2
+        assert mock_logger.debug.call_count == 2
     
     @patch('adk_middleware.endpoint.EventEncoder')
     @patch('adk_middleware.endpoint.logger')


### PR DESCRIPTION
## Summary
- Fixed failing test that was checking for info level logging when endpoint uses debug level
- Updated test assertion to check `mock_logger.debug.call_count` instead of `mock_logger.info.call_count`

## Test plan
- [x] All 280 tests pass
- [x] Verified the endpoint correctly uses debug level for HTTP response logging
- [x] Test now properly validates the expected logging behavior

🤖 Generated with [Claude Code](https://claude.ai/code)