### PR TITLE
fix: resolve EventType.STATE_DELTA patch error (issue #20)

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/event_translator.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/event_translator.py
@@ -295,11 +295,11 @@ class EventTranslator:
             A StateDeltaEvent
         """
         # Convert to JSON Patch format (RFC 6902)
-        # For now, we'll use a simple "replace" operation for each key
+        # Use "add" operation which works for both new and existing paths
         patches = []
         for key, value in state_delta.items():
             patches.append({
-                "op": "replace",
+                "op": "add",
                 "path": f"/{key}",
                 "value": value
             })


### PR DESCRIPTION
- Change from "replace" to "add" operations in state delta events
- JSON Patch "add" works for both new and existing paths
- Fixes "OPERATION_PATH_UNRESOLVABLE" errors on frontend
- Update existing tests to expect "add" operations
- Add comprehensive test coverage for edge cases:
  * Nested objects and arrays
  * Mixed value types (string, number, boolean, null)
  * Special characters in keys

🤖 Generated with [Claude Code](https://claude.ai/code)