### PR TITLE
Add e2e tests for ADK middleware agentic chat

### DIFF
--- a/typescript-sdk/apps/dojo/e2e2/tests/adk-middleware-agentic-chat.spec.ts
+++ b/typescript-sdk/apps/dojo/e2e2/tests/adk-middleware-agentic-chat.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('responds to user message', async ({ page }) => {
+  await page.goto('http://localhost:9999/adk-middleware/feature/agentic_chat');
+
+  // 1. Wait for the page to be fully ready by ensuring the initial message is visible.
+  await expect(page.getByText("Hi, I'm an agent. Want to chat?")).toBeVisible({ timeout: 10000 });
+
+  // 2. Interact with the page to send the message.
+  const textarea = page.getByPlaceholder('Type a message...');
+  await textarea.fill('How many sides are in a square? Please answer in one word. Do not use any punctuation, just the number in word form.');
+  await page.keyboard.press('Enter');
+
+  // 3. Assert the final state with a generous timeout.
+  //    This is the most important part. We target the *second* assistant message
+  //    and wait for it to contain the text "Four". Playwright handles all the waiting.
+  const finalResponse = page.locator('.copilotKitMessage.copilotKitAssistantMessage').nth(1);
+  await expect(finalResponse).toContainText(/four/i, { timeout: 15000 });
+
+  // 4. (Optional) For added certainty, verify the total message count.
+  //    This confirms there are exactly 3 messages: greeting, user query, and agent response.
+  await expect(page.locator('.copilotKitMessage')).toHaveCount(3);
+});


### PR DESCRIPTION
- Create Playwright test for ADK middleware integration
- Test initial greeting message display
- Test agent response to user question ("Four")
- Properly wait for second assistant message with timeout
- Verify complete conversation flow (3 messages total)

🤖 Generated with [Claude Code](https://claude.ai/code) with assistance from Google Gemini