### PR TITLE
feat: Make ADK middleware base URL configurable via environment variable

### DIFF
--- a/typescript-sdk/apps/dojo/src/agents.ts
+++ b/typescript-sdk/apps/dojo/src/agents.ts
@@ -63,11 +63,11 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     id: "adk-middleware",
     agents: async () => {
       return {
-        agentic_chat: new ServerStarterAgent({ url: "http://localhost:8000/chat" }),
-        tool_based_generative_ui: new ServerStarterAgent({ url: "http://localhost:8000/adk-tool-based-generative-ui" }),
-        human_in_the_loop: new ServerStarterAgent({ url: "http://localhost:8000/adk-human-in-loop-agent" }),
-        shared_state: new ServerStarterAgent({ url: "http://localhost:8000/adk-shared-state-agent" }),
-        predictive_state_updates: new ServerStarterAgent({ url: "http://localhost:8000/adk-predictive-state-agent" }),
+        agentic_chat: new ServerStarterAgent({ url: `${envVars.adkMiddlewareUrl}/chat` }),
+        tool_based_generative_ui: new ServerStarterAgent({ url: `${envVars.adkMiddlewareUrl}/adk-tool-based-generative-ui` }),
+        human_in_the_loop: new ServerStarterAgent({ url: `${envVars.adkMiddlewareUrl}/adk-human-in-loop-agent` }),
+        shared_state: new ServerStarterAgent({ url: `${envVars.adkMiddlewareUrl}/adk-shared-state-agent` }),
+        predictive_state_updates: new ServerStarterAgent({ url: `${envVars.adkMiddlewareUrl}/adk-predictive-state-agent` }),
       };
     },
   },

--- a/typescript-sdk/apps/dojo/src/env.ts
+++ b/typescript-sdk/apps/dojo/src/env.ts
@@ -8,6 +8,7 @@ type envVars = {
   llamaIndexUrl: string;
   crewAiUrl: string;
   pydanticAIUrl: string;
+  adkMiddlewareUrl: string;
   customDomainTitle: Record<string, string>;
 }
 
@@ -30,6 +31,7 @@ export default function getEnvVars(): envVars {
     llamaIndexUrl: process.env.LLAMA_INDEX_URL || 'http://localhost:9000',
     crewAiUrl: process.env.CREW_AI_URL || 'http://localhost:9002',
     pydanticAIUrl: process.env.PYDANTIC_AI_URL || 'http://localhost:9000',
+    adkMiddlewareUrl: process.env.ADK_MIDDLEWARE_URL || 'http://localhost:8000',
     customDomainTitle: customDomainTitle,
   }
 }

--- a/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
+++ b/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **CONFIG**: Made ADK middleware base URL configurable via `ADK_MIDDLEWARE_URL` environment variable in dojo app
+- **CONFIG**: Added `adkMiddlewareUrl` configuration to environment variables (defaults to `http://localhost:8000`)
+
 ## [0.5.0] - 2025-08-05
 
 ### Breaking Changes


### PR DESCRIPTION
- Add ADK_MIDDLEWARE_URL environment variable support in dojo app
- Configure adkMiddlewareUrl in env.ts with default to http://localhost:8000
- Update all ADK middleware agent URLs to use the configurable base URL
- Update CHANGELOG to document configuration changes

🤖 Generated with [Claude Code](https://claude.ai/code)