### PR TITLE
feat: Upgrade Google ADK dependency to 1.9.0

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
+++ b/typescript-sdk/integrations/adk-middleware/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **CONFIG**: Made ADK middleware base URL configurable via `ADK_MIDDLEWARE_URL` environment variable in dojo app
 - **CONFIG**: Added `adkMiddlewareUrl` configuration to environment variables (defaults to `http://localhost:8000`)
+- **DEPENDENCIES**: Upgraded Google ADK from 1.6.1 to 1.9.0 - all 271 tests pass without modification
 
 ## [0.5.0] - 2025-08-05
 

--- a/typescript-sdk/integrations/adk-middleware/requirements.txt
+++ b/typescript-sdk/integrations/adk-middleware/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 ag-ui-protocol>=0.1.7
-google-adk>=1.6.1
+google-adk>=1.9.0
 pydantic>=2.11.7
 asyncio>=3.4.3
 fastapi>=0.115.2


### PR DESCRIPTION
- Updated google-adk from 1.6.1 to 1.9.0 in requirements.txt
- All 271 tests pass successfully with the new version
- No code changes required for compatibility
- Updated CHANGELOG.md with dependency upgrade information

🤖 Generated with [Claude Code](https://claude.ai/code)