### PR TITLE
Add start commands for production mode

### DIFF
--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -7,6 +7,7 @@
     "clean": "rm -rf dist .turbo node_modules && pnpm -r clean",
     "build:clean": "rm -rf dist .turbo node_modules && pnpm -r clean && pnpm install && turbo run build",
     "dev": "turbo run dev",
+    "start": "turbo run start",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md,mdx}\"",
     "check-types": "turbo run check-types",

--- a/typescript-sdk/turbo.json
+++ b/typescript-sdk/turbo.json
@@ -42,6 +42,11 @@
     },
     "unlink:global": {
       "cache": false
+    },
+    "start": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added `start` commands to enable running the dojo in production mode
- Users can now use `pnpm run start` for production vs `pnpm run dev` for development

## Changes
- Added start script in package.json files for production mode execution

🤖 Generated with [Claude Code](https://claude.ai/code)