### PR TITLE
fix: iOS app crash due to missing CADisableMinimumFrameDurationOnPhone

### DIFF
--- a/kotlin-sdk/examples/chatapp/iosApp/iosApp/Info.plist
+++ b/kotlin-sdk/examples/chatapp/iosApp/iosApp/Info.plist
@@ -65,5 +65,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add required Info.plist entry for Compose Multiplatform iOS support. This key is strictly enforced since Compose Multiplatform 1.6.10 to ensure proper support for high refresh rate displays (120Hz).

Without this key, the app crashes during initialization with: PlistSanityCheck.performIfNeeded throwing a Kotlin/Native exception.

Addresses https://github.com/Contextable/ag-ui/issues/56

🤖 Generated with [Claude Code](https://claude.ai/code)