### PR TITLE
fix: make error handling test more robust

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/tests/test_adk_agent.py
+++ b/typescript-sdk/integrations/adk-middleware/tests/test_adk_agent.py
@@ -174,7 +174,9 @@ class TestADKAgent:
         assert events[0].type == EventType.RUN_STARTED
         assert events[1].type == EventType.RUN_ERROR
         assert events[2].type == EventType.RUN_FINISHED
-        assert "validation error" in events[1].message
+        # Check that it's an error with meaningful content
+        assert len(events[1].message) > 0
+        assert events[1].code == 'BACKGROUND_EXECUTION_ERROR'
     
     @pytest.mark.asyncio
     async def test_cleanup(self, adk_agent):


### PR DESCRIPTION
Replace brittle string matching in test_error_handling with more reliable assertions that check for error code and message presence instead of specific error message content. This prevents test failures when underlying error messages change.

🤖 Generated with [Claude Code](https://claude.ai/code)