### PR TITLE
feat: upgrade Google ADK requirement to >=1.14.0

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/requirements.txt
+++ b/typescript-sdk/integrations/adk-middleware/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 ag-ui-protocol>=0.1.7
-google-adk>=1.9.0
+google-adk>=1.14.0
 pydantic>=2.11.7
 asyncio>=3.4.3
 fastapi>=0.115.2

--- a/typescript-sdk/integrations/adk-middleware/setup.py
+++ b/typescript-sdk/integrations/adk-middleware/setup.py
@@ -36,7 +36,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "ag-ui-protocol>=0.1.7",
-        "google-adk>=1.9.0",
+        "google-adk>=1.14.0",
         "pydantic>=2.11.7",
         "asyncio>=3.4.3",
         "fastapi>=0.115.2",


### PR DESCRIPTION
- Update google-adk requirement from >=1.9.0 to >=1.14.0 in both setup.py and requirements.txt
- All 277 tests pass with ADK 1.14.1, confirming compatibility
- No breaking changes or code modifications required

🤖 Generated with [Claude Code](https://claude.ai/code)