### PR TITLE
refactor: remove redundant execution checks in _start_new_execution

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/src/adk_middleware/adk_agent.py
+++ b/typescript-sdk/integrations/adk-middleware/src/adk_middleware/adk_agent.py
@@ -619,14 +619,12 @@ class ADKAgent:
                             f"Maximum concurrent executions ({self._max_concurrent}) reached"
                         )
                 
-                # Check if there's an existing execution for this thread
+                # Check if there's an existing execution for this thread and wait for it
                 existing_execution = self._active_executions.get(input.thread_id)
-                if existing_execution and not existing_execution.is_complete:
-                    # Wait for existing execution to complete before starting new one
-                    logger.debug(f"Waiting for existing execution to complete for thread {input.thread_id}")
-            
+
             # If there was an existing execution, wait for it to complete
             if existing_execution and not existing_execution.is_complete:
+                logger.debug(f"Waiting for existing execution to complete for thread {input.thread_id}")
                 try:
                     await existing_execution.task
                 except Exception as e:


### PR DESCRIPTION
## Summary
- Remove redundant execution checks in the `_start_new_execution` method
- Simplify code by consolidating duplicate condition checking into a single block
- Maintain identical functional behavior while improving code clarity

## Problem
The original code performed two nearly identical checks for existing executions:
1. First check that only logged a message
2. Second check that actually waited for the execution to complete

This redundancy made the code less maintainable and harder to read.

## Solution
- Consolidate the execution existence check into a single, more efficient block
- Remove the unnecessary first check that only logged
- Keep the functional logic (waiting for execution completion) intact
- Improve code readability and reduce complexity

## Changes
- **Before**: Two separate checks for `existing_execution and not existing_execution.is_complete`
- **After**: Single check with consolidated logging and waiting logic
- **Impact**: -2 lines of code, improved maintainability, no functional changes

## Test Results
- All 277 existing tests pass
- All 26 execution-related tests pass
- No breaking changes to functionality

## Addresses
Fixes #72: Remove redundant code checks

🤖 Generated with [Claude Code](https://claude.ai/code)